### PR TITLE
improve message creation error handling

### DIFF
--- a/inlineplz/message.py
+++ b/inlineplz/message.py
@@ -11,11 +11,16 @@ class Messages(object):
 
     def add_message(self, path, line, message):
         path = os.path.relpath(path).replace('\\', '/')
+        # some linters return line=null for file comments
+        if not line:
+            line = 0
         if (path, line) not in self.messages:
             try:
                 self.messages[(path, line)] = Message(path, line)
             except TypeError:
+                print('{0} {1} {2}'.format(path, line, message))
                 traceback.print_exc()
+                return
         self.messages[(path, line)].append(message)
 
     def add_messages(self, messages):

--- a/inlineplz/message.py
+++ b/inlineplz/message.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+"""Wrap linter messages in a generic Message class that can do some internal cleanup."""
+
+from __future__ import print_function
+
 import os
 import traceback
 


### PR DESCRIPTION
this is for this error:
```
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/message.py", line 16, in add_message
    self.messages[(path, line)] = Message(path, line)
  File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/message.py", line 33, in __init__
    self.line_number = int(line_number)
TypeError: int() argument must be a string or a number, not 'NoneType'
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/linters/__init__.py", line 340, in lint
    messages.add_messages(linter_messages)
  File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/message.py", line 23, in add_messages
    self.add_message(*message)
  File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/message.py", line 19, in add_message
    self.messages[(path, line)].append(message)
KeyError: (u'node_modules/sanitize-filename/vendor/big-list-of-naughty-strings/scripts/txt_to_json.py', None)
```
@raphaelcastaneda 