### PR TITLE
#107 set max comments per file in github interface

### DIFF
--- a/inlineplz/interfaces/github.py
+++ b/inlineplz/interfaces/github.py
@@ -43,6 +43,7 @@ class GitHubInterface(InterfaceBase):
         paths = dict()
 
         # randomize message order to more evenly distribute messages across different files
+        messages = list(messages)
         random.shuffle(messages)
         for msg in messages:
             if not msg.comments:

--- a/inlineplz/interfaces/github.py
+++ b/inlineplz/interfaces/github.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import division
+
+import random
 
 import github3
 import unidiff
@@ -37,6 +40,10 @@ class GitHubInterface(InterfaceBase):
             return
         messages_to_post = 0
         messages_posted = 0
+        paths = dict()
+
+        # randomize message order to more evenly distribute messages across different files
+        random.shuffle(messages)
         for msg in messages:
             if not msg.comments:
                 continue
@@ -44,6 +51,10 @@ class GitHubInterface(InterfaceBase):
             if msg_position:
                 messages_to_post += 1
                 if not self.is_duplicate(msg, msg_position):
+                    # skip this message if we already have too many comments on this file
+                    # max comments / 5 is an arbitrary number i totally made up. should maybe be configurable.
+                    if paths.setdefault(msg.path, 0) > max_comments // 5:
+                        continue
                     try:
                         self.pull_request.create_review_comment(
                             self.format_message(msg),
@@ -53,6 +64,7 @@ class GitHubInterface(InterfaceBase):
                         )
                     except github3.GitHubError:
                         pass
+                    paths[msg.path] += 1
                     messages_posted += 1
                     if max_comments >= 0 and messages_posted > max_comments:
                         break


### PR DESCRIPTION
resolves #107 @raphaelcastaneda i did this implementation purely within the interface so that we can handle this differently per interface/review tool.