### PR TITLE
replace decode errors

### DIFF
--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import fnmatch
 from multiprocessing.pool import ThreadPool as Pool

--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -183,9 +183,9 @@ def run_command(command, log_on_fail=False, log_all=False):
     )
     stdout, stderr = proc.communicate()
     if stdout:
-        stdout = stdout.decode('utf-8')
+        stdout = stdout.decode('utf-8', errors='replace')
     if stderr:
-        stderr = stderr.decode('utf-8')
+        stderr = stderr.decode('utf-8', errors='replace')
     if (log_on_fail and proc.returncode) or log_all:
         print((stdout or '') + (stderr or ''))
     return proc.returncode, (stdout or '') + (stderr or '')

--- a/inlineplz/util/git.py
+++ b/inlineplz/util/git.py
@@ -6,7 +6,7 @@ import subprocess
 def current_sha():
     return subprocess.check_output(
         ['git', 'rev-parse', 'HEAD']
-    ).strip().decode('utf-8')
+    ).strip().decode('utf-8', errors='replace')
 
 
 def diff(start, end):
@@ -18,4 +18,4 @@ def diff(start, end):
 def parent_sha(sha):
     return subprocess.check_output(
         ['git', 'rev-list', '--parents', '-n', '1', sha]
-    ).strip().decode('utf-8').split()[1]
+    ).strip().decode('utf-8', errors='replace').split()[1]


### PR DESCRIPTION
```
00:00:56.907 Traceback (most recent call last):
00:00:56.907   File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/linters/__init__.py", line 321, in lint
00:00:56.907     install_linter(config)
00:00:56.908   File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/linters/__init__.py", line 286, in install_linter
00:00:56.908     run_command(install_cmd, log_all=True)
00:00:56.908   File "/home/jenkins/.local/lib/python2.7/site-packages/inlineplz/linters/__init__.py", line 190, in run_command
00:00:56.908     print((stdout or '') + (stderr or ''))
00:00:56.908 UnicodeEncodeError: 'ascii' codec can't encode characters in position 679-681: ordinal not in range(128)
```