### PR TITLE
add explicit jscs dir exclusions

### DIFF
--- a/inlineplz/linters/config/.jscsrc
+++ b/inlineplz/linters/config/.jscsrc
@@ -64,5 +64,6 @@
     "escape": true,
     "mark": "'"
   },
-  "validateIndentation": 2
+  "validateIndentation": 2,
+  "excludeFiles": ["node_modules/**", ".git/**"]
 }


### PR DESCRIPTION
@vsiakka 

apparently in jscs 3.x (released today) we need to explicitly exclude directories :(