### PR TITLE
use time.time instead of time.clock

### DIFF
--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -343,7 +343,7 @@ def lint(install=False, autorun=False, ignore_paths=None, config_dir=None):
     for linter in linters_to_run(install, autorun, ignore_paths):
         print('Running linter: {0}'.format(linter))
         sys.stdout.flush()
-        start = time.clock()
+        start = time.time()
         output = ''
         config = LINTERS.get(linter)
         try:
@@ -358,9 +358,9 @@ def lint(install=False, autorun=False, ignore_paths=None, config_dir=None):
         except Exception:
             traceback.print_exc()
             print(str(output).encode('ascii', errors='replace'))
-        print('Installation and running of {0} took {1} seconds'.format(linter, int(time.clock() - start)))
+        print('Installation and running of {0} took {1} seconds'.format(linter, int(time.time() - start)))
         sys.stdout.flush()
-        start = time.clock()
+        start = time.time()
         try:
             if output:
                 linter_messages = config.get('parser')().parse(output)
@@ -372,5 +372,5 @@ def lint(install=False, autorun=False, ignore_paths=None, config_dir=None):
         except Exception:
             traceback.print_exc()
             print(str(output).encode('ascii', errors='replace'))
-        print('Parsing of {0} took {1} seconds'.format(linter, int(time.clock() - start)))
+        print('Parsing of {0} took {1} seconds'.format(linter, int(time.time() - start)))
     return messages.get_messages()

--- a/inlineplz/main.py
+++ b/inlineplz/main.py
@@ -44,9 +44,9 @@ def main():
     if args.config_dir:
         args.config_dir = os.path.abspath(args.config_dir)
     print('inline-plz version: {}'.format(__version__))
-    start = time.clock()
+    start = time.time()
     result = inline(args)
-    print('inline-plz ran for {} seconds'.format(int(time.clock() - start)))
+    print('inline-plz ran for {} seconds'.format(int(time.time() - start)))
     return result
 
 


### PR DESCRIPTION
time.clock isn't reporting elapsed wall clock seconds on some OSes.