### PR TITLE
pin unidiff to 0.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'unidiff',
+    'unidiff==0.5.4',
     'github3.py',
     'xmltodict',
     'pyyaml',


### PR DESCRIPTION
workaround until https://github.com/matiasb/python-unidiff/issues/54 is resolved