### PR TITLE
make the linter names less redundant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,10 @@ For example:
   enabled_linters:
     - prospector
   disabled_linters:
-    - markdownlint
-    - gherkin-lint
+    - markdown
+    - gherkin
+
+For more see the examples folder in the repo.
 
 
 Known issues

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,8 @@ For example:
   enabled_linters:
     - prospector
   disabled_linters:
-    - markdown
-    - gherkin
+    - markdownlint-cli
+    - gherkin-lint
 
 For more see the examples folder in the repo.
 

--- a/examples/all-the-linters-enabled.inlineplz.yml
+++ b/examples/all-the-linters-enabled.inlineplz.yml
@@ -1,0 +1,18 @@
+# from linters/__init__.py
+enabled_linters:
+  - bandit
+  - dockerfile
+  - eslint
+  - gherkin
+  - gometalinter
+  - jscs
+  - jshint
+  - jsonlint
+  - markdownlint
+  - megacheck
+  - prospector
+  - rflint
+  - rst
+  - shellcheck
+  - stylint
+  - yaml

--- a/examples/all-the-linters-enabled.inlineplz.yml
+++ b/examples/all-the-linters-enabled.inlineplz.yml
@@ -1,18 +1,18 @@
 # from linters/__init__.py
 enabled_linters:
   - bandit
-  - dockerfile
+  - dockerfile_lint
   - eslint
-  - gherkin
+  - gherkin-lint
   - gometalinter
   - jscs
   - jshint
   - jsonlint
-  - markdownlint
+  - markdownlint-cli
   - megacheck
   - prospector
-  - rflint
-  - rst
+  - robotframework-lint
+  - restructuredtext_lint
   - shellcheck
   - stylint
-  - yaml
+  - yamllint

--- a/examples/your-standard-node-app.inlineplz.yml
+++ b/examples/your-standard-node-app.inlineplz.yml
@@ -1,0 +1,24 @@
+ignore_paths:
+  - node_modules
+  - vendors
+  - .tox
+  - .git
+enabled_linters:
+  - markdown
+  - eslint
+  - json
+disabled_linters:
+  - bandit
+  - dockerfile
+  - gherkin
+  - gometalinter
+  - jscs
+  - jshint
+  - markdownlint
+  - megacheck
+  - prospector
+  - rflint
+  - rst
+  - shellcheck
+  - stylint
+  - yaml

--- a/examples/your-standard-node-app.inlineplz.yml
+++ b/examples/your-standard-node-app.inlineplz.yml
@@ -9,16 +9,16 @@ enabled_linters:
   - json
 disabled_linters:
   - bandit
-  - dockerfile
-  - gherkin
+  - dockerfile_lint
+  - gherkin-lint
   - gometalinter
   - jscs
   - jshint
-  - markdownlint
+  - markdownlint-cli
   - megacheck
   - prospector
-  - rflint
-  - rst
+  - robotframework-lint
+  - restructuredtext_lint
   - shellcheck
   - stylint
-  - yaml
+  - yamllint

--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -82,7 +82,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'dockerfile_lint': {
+    'dockerfile': {
         'install': [['npm', 'install', 'dockerfile_lint']],
         'help':
         [os.path.normpath('./node_modules/.bin/dockerfile_lint'), '-h'],
@@ -114,7 +114,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'gherkin-lint': {
+    'gherkin': {
         'install': [['npm', 'install', 'gherkin-lint']],
         'help':
         [os.path.normpath('./node_modules/.bin/gherkin-lint'), '--help'],
@@ -244,7 +244,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': True
     },
-    'rst-lint': {
+    'rst': {
         'install': [['pip', 'install', '-U', 'restructuredtext_lint']],
         'help': ['rst-lint', '-h'],
         'run': ['rst-lint', '--format', 'json'],
@@ -288,7 +288,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'yaml-lint': {
+    'yaml': {
         'install': [['pip', 'install', 'yamllint']],
         'help': ['yamllint', '-h'],
         'run': ['yamllint', '-f', 'parsable', '.'],

--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -82,7 +82,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'dockerfile': {
+    'dockerfile_lint': {
         'install': [['npm', 'install', 'dockerfile_lint']],
         'help':
         [os.path.normpath('./node_modules/.bin/dockerfile_lint'), '-h'],
@@ -114,7 +114,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'gherkin': {
+    'gherkin-lint': {
         'install': [['npm', 'install', 'gherkin-lint']],
         'help':
         [os.path.normpath('./node_modules/.bin/gherkin-lint'), '--help'],
@@ -193,7 +193,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': True
     },
-    'markdownlint': {
+    'markdownlint-cli': {
         'install': [['npm', 'install', 'markdownlint-cli']],
         'help': [os.path.normpath('./node_modules/.bin/markdownlint'), '-h'],
         'run': [os.path.normpath('./node_modules/.bin/markdownlint'), '.'],
@@ -233,7 +233,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'rflint': {
+    'robotframework-lint': {
         'install': [['pip', 'install', '-U', 'robotframework-lint']],
         'help': ['rflint', '--help'],
         'run': ['rflint'],
@@ -244,7 +244,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': True
     },
-    'rst': {
+    'restructuredtext_lint': {
         'install': [['pip', 'install', '-U', 'restructuredtext_lint']],
         'help': ['rst-lint', '-h'],
         'run': ['rst-lint', '--format', 'json'],
@@ -288,7 +288,7 @@ LINTERS = {
         'autorun': True,
         'run_per_file': False
     },
-    'yaml': {
+    'yamllint': {
         'install': [['pip', 'install', 'yamllint']],
         'help': ['yamllint', '-h'],
         'run': ['yamllint', '-f', 'parsable', '.'],


### PR DESCRIPTION
The linter names are user interface and it isn't uniform. Here I am proposing new names that remove the word linter and any dashes or underscores that precedes it.

Of course this is not tested yet because first I got to check if the proposal is accepted as is or with modifications.