### PR TITLE
disable vetshadow by default

### DIFF
--- a/inlineplz/linters/config/.gometalinter.json
+++ b/inlineplz/linters/config/.gometalinter.json
@@ -1,3 +1,3 @@
 {
-  "Enable": ["deadcode", "unconvert", "structcheck", "gotype", "gotypex", "vetshadow", "varcheck", "megacheck"]
+  "Enable": ["deadcode", "unconvert", "structcheck", "gotype", "gotypex", "varcheck", "megacheck"]
 }


### PR DESCRIPTION
vetshadow can be a little noisy, especially about `err`.