### PR TITLE
two transitive dependencies not automatically handled by pip: python-…

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,5 @@ py==1.5.3
 pytest==3.7.0
 PyYAML==3.13
 prospector[with_everything]==1.1.1
+python-dateutil>=2.6.0
+requests>=2.18


### PR DESCRIPTION
* python-dateutil>=2.6.0
* requests>=2.18

After setting up for development, the dryrun failed b/c of the version mismatch on `python-dateutil`.  `requests` caused a warning during the pip install for `github3`.  