### PR TITLE
edit messages that ARENT dupes

### DIFF
--- a/inlineplz/interfaces/github.py
+++ b/inlineplz/interfaces/github.py
@@ -271,7 +271,7 @@ class GitHubInterface(InterfaceBase):
 
     def is_duplicate(self, message, position):
         msg = self.message_at_position(message, position)
-        if msg.body.strip() == self.format_message(message).strip():
+        if msg and msg.body.strip() == self.format_message(message).strip():
             return msg
         return None
 

--- a/inlineplz/linters/detectsecrets.py
+++ b/inlineplz/linters/detectsecrets.py
@@ -10,8 +10,7 @@ from inlineplz.parsers.base import ParserBase
 from inlineplz.decorators import linter
 
 
-@linter(  # TODO: switch this to installing from pypi once they release my fix from https://github.com/Yelp/detect-secrets/pull/69
-    # "install": [[sys.executable, "-m", "pip", "install", "-U", "detect-secrets"]],
+@linter(
     name="detect-secrets",
     install=[[sys.executable, "-m", "pip", "install", "-U", "detect-secrets"]],
     help_cmd=["detect-secrets", "-h"],


### PR DESCRIPTION
we were previously editing dupes, but that doesn't actually make any sense. what does make sense is editing old comments that are on the same line but are different.