### PR TITLE
install openssl

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,4 @@ prospector[with_everything]==1.1.6.2
 python-dateutil>=2.6.0
 requests>=2.18
 black>=18.9b0; python_version >= '3.6'
+pyOpenSSL


### PR DESCRIPTION
upload to pypi is failing with:
```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/requests_toolbelt/_compat.py", line 56, in <module>
    from requests.packages.urllib3.contrib.pyopenssl \
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
ModuleNotFoundError: No module named 'OpenSSL'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.7/bin/twine", line 6, in <module>
    from twine.__main__ import main
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/twine/__main__.py", line 23, in <module>
    from twine.cli import dispatch
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/twine/cli.py", line 23, in <module>
    import requests_toolbelt
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/requests_toolbelt/__init__.py", line 12, in <module>
    from .adapters import SSLAdapter, SourceAddressAdapter
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/requests_toolbelt/adapters/__init__.py", line 12, in <module>
    from .ssl import SSLAdapter
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/requests_toolbelt/adapters/ssl.py", line 16, in <module>
    from .._compat import poolmanager
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/requests_toolbelt/_compat.py", line 59, in <module>
    from urllib3.contrib.pyopenssl import PyOpenSSLContext
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
ModuleNotFoundError: No module named 'OpenSSL'
```