### PR TITLE
fix parsing of yamllint errors

### DIFF
--- a/inlineplz/linters/proselint.py
+++ b/inlineplz/linters/proselint.py
@@ -14,7 +14,7 @@ from ..parsers.base import ParserBase
     rundefault=["proselint"],
     dotfiles=[],
     language="text",
-    autorun=True,
+    autorun=False,
     run_per_file=True,
     concurrency=1,
 )

--- a/inlineplz/linters/yamllint.py
+++ b/inlineplz/linters/yamllint.py
@@ -25,7 +25,7 @@ class YAMLLintParser(ParserBase):
         for line in lint_data.split("\n"):
             try:
                 if line.strip():
-                    parts = line.split(":")
+                    parts = line.split(":", 3)
                     path = parts[0].strip()
                     line = int(parts[1].strip())
                     msgbody = parts[3].strip()


### PR DESCRIPTION
in messages like `[error] syntax error: mapping values are not allowed here` we were losing everythign after the colon.

also disabling autorun of proselint because in many use cases its not really that helpful.