### PR TITLE
Get woke integration

### DIFF
--- a/inlineplz/linters/__init__.py
+++ b/inlineplz/linters/__init__.py
@@ -43,6 +43,7 @@ from ..linters.spotbugsmaven import SpotbugsMavenParser  # NOQA
 from ..linters.stylint import StylintParser  # NOQA
 from ..linters.tflint import TFLintParser  # NOQA
 from ..linters.yamllint import YAMLLintParser  # NOQA
+from ..linters.woke import WokeParser #NOQA
 
 
 def register_patterns():

--- a/inlineplz/linters/woke.py
+++ b/inlineplz/linters/woke.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+from ..decorators import linter
+from ..parsers.base import ParserBase
+
+
+@linter(
+    name="woke",
+    language="all",
+    patterns=["*.*"],
+    install=[["go", "install", "github.com/get-woke/woke@latest"]],
+    help_cmd=["woke", "--help"],
+    run=["woke"],
+    rundefault=["woke"],
+    dotfiles=[],
+    autorun=True,
+    run_per_file=False,
+)
+class WokeParser(ParserBase):
+    """Parse woke output."""
+
+    def parse(self, lint_data):
+        messages = set()
+        lines = re.compile(r"\^\n").split(lint_data)
+        line_pat = re.compile(r"^(.+?):(\d+):(.+): (.+)\n")
+
+        for line in lines:
+            match = line_pat.search(line)
+            if not match:
+                continue
+            messages.add(
+                (
+                    match.group(1).strip(),
+                    int(match.group(2).strip()),
+                    match.group(4).strip(),
+                )
+            )
+
+        return messages
+
+

--- a/inlineplz/linters/woke.py
+++ b/inlineplz/linters/woke.py
@@ -23,8 +23,8 @@ class WokeParser(ParserBase):
 
     def parse(self, lint_data):
         messages = set()
-        lines = re.compile(r"\^\n").split(lint_data)
-        line_pat = re.compile(r"^(.+?):(\d+):(.+): (.+)\n")
+        lines = re.compile(r"\n").split(lint_data)
+        line_pat = re.compile(r"^(.+?):(\d+):(.+): (.+ \(.+\))")
 
         for line in lines:
             match = line_pat.search(line)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ Sphinx==4.0.2
 py==1.10.0
 pytest==6.2.4
 PyYAML==5.4.1
-prospector[with_everything]==1.3.1
+prospector[with_everything]==1.7.7
 python-dateutil>=2.6.0
 requests>=2.18
 black>=18.9b0; python_version >= '3.6'

--- a/tests/parsers/test_woke.py
+++ b/tests/parsers/test_woke.py
@@ -35,7 +35,7 @@ def test_woke():
         messages = sorted(list(woke.WokeParser().parse(inputfile.read())))
         assert len(expected_messages) == len(messages)
 
-        for i in range(len(messages)):
+        for i, _ in enumerate(messages):
             assert messages[i][2] == expected_messages[i][2]
             assert messages[i][1] == expected_messages[i][1]
             assert messages[i][0] == expected_messages[i][0]

--- a/tests/parsers/test_woke.py
+++ b/tests/parsers/test_woke.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import codecs
+import os
+
+import inlineplz.linters.woke as woke
+
+woke_path = os.path.join("tests", "testdata", "parsers", "woke.txt")
+
+expected_messages = list()
+expected_messages.append(
+    ("sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala"
+     , 406
+     , "`dummy` may be insensitive, use `placeholder`, `sample` instead (error)")
+)
+expected_messages.append(
+    ("sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala"
+     , 208
+     , "`dummy` may be insensitive, use `placeholder`, `sample` instead (error)")
+)
+expected_messages.append(
+    ("docs/js/vendor/bootstrap.bundle.min.js.map"
+     , 1
+     , "`whiteList` may be insensitive, use `allowlist`, `inclusion list` instead (warning)")
+)
+expected_messages.append(
+    ("sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala"
+     , 107
+     , "`sanity` may be insensitive, use `confidence`, `quick check`, `coherence check` instead (error)")
+)
+expected_messages = sorted(expected_messages)
+
+def test_woke():
+    with codecs.open(woke_path, encoding="utf-8", errors="replace") as inputfile:
+        messages = sorted(list(woke.WokeParser().parse(inputfile.read())))
+        assert len(expected_messages) == len(messages)
+
+        for i in range(len(messages)):
+            assert messages[i][2] == expected_messages[i][2]
+            assert messages[i][1] == expected_messages[i][1]
+            assert messages[i][0] == expected_messages[i][0]

--- a/tests/testdata/parsers/woke.txt
+++ b/tests/testdata/parsers/woke.txt
@@ -1,0 +1,10 @@
+sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala:406:38-43: `dummy` may be insensitive, use `placeholder`, `sample` instead (error)
+    // TODO(josh): We won't need this dummy memory manager after future refactorings; revisit
+                                      ^
+sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala:208:82-87: `dummy` may be insensitive, use `placeholder`, `sample` instead (error)
+      // SPARK-23271 If we are attempting to write a zero partition rdd, create a dummy single
+                                                                                  ^
+docs/js/vendor/bootstrap.bundle.min.js.map:1:289699-289708: `whiteList` may be insensitive, use `allowlist`, `inclusion list` instead (warning)
+sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala:107:14-20: `sanity` may be insensitive, use `confidence`, `quick check`, `coherence check` instead (error)
+  private def sanityCheck(plan: SparkPlan): Boolean =
+              ^

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37
+envlist = py37, py38, py39
 
 [testenv]
 setenv =


### PR DESCRIPTION
New features added:
1. Integrate woke to detect exclusive words in code

Python version & dependency change:
1. Remove support for Python 3.5 & 3.6, add support to Python 3.8 & 3.9. (3.10 is not added because dirtyjson doesn't work under 3.10.)
2. Update prospector from 1.3.1 to 1.7.7 to resolve conflicts with flake8